### PR TITLE
fixed passign "pragmas" params to Mustache Engine

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,6 +90,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('loader_id')->defaultValue('mustache.loader')->end()
                 ->scalarNode('partials_loader_id')->defaultValue('mustache.loader')->end()
                 ->scalarNode('charset')->defaultValue('%kernel.charset%')->end()
+                ->arrayNode('pragmas')
+                    ->prototype('scalar')->end()
+                ->end()
             ->end()
         ;
     }


### PR DESCRIPTION
The current implementation doesn't pass the pragmas param into the Mustache Engine.
It's either a bug in the BobthecowMustacheExtension class - line 77 (master) around handling "globals" or - simple overlook of the support for this option in the Configuration.php

This is the config entry that works with the fix:
bobthecow_mustache:
    pragmas: ["FILTERS", "BLOCKS"]

This is the config that I have tried using and did not work with default implementation:
bobthecow_mustache:
     globals:
        pragmas: ["FILTERS", "BLOCKS"]
