### PR TITLE
Remove superfluous argument

### DIFF
--- a/Resources/config/mustache.xml
+++ b/Resources/config/mustache.xml
@@ -31,7 +31,6 @@
         <service id="templating.engine.mustache" class="%templating.engine.mustache.class%" public="false">
             <argument type="service" id="mustache" />
             <argument type="service" id="templating.name_parser" />
-            <argument type="service" id="templating.globals" />
         </service>
 
         <service id="assetic.mustache_formula_loader" class="%assetic.mustache_formula_loader.class%" public="false">


### PR DESCRIPTION
This argument is unused, so should be removed.

Also, as of Symfony 2.7 that service is only available if PHP templating is enabled (see https://github.com/symfony/symfony/issues/14719). If it isn't, the bundle's broken.
